### PR TITLE
feat: Sign Plugin for distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: grafana/plugin-actions/build-plugin@release
-          # Uncomment to enable plugin signing
-          # (For more info on how to generate the access policy token see https://grafana.com/developers/plugin-tools/publish-a-plugin/sign-a-plugin#generate-an-access-policy-token)
-          #with:
-          # Make sure to save the token in your repository secrets
-          #policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}
-          # Usage of GRAFANA_API_KEY is deprecated, prefer `policy_token` option above
-        #grafana_token: ${{ secrets.GRAFANA_API_KEY }}
+        with:
+          policy_token: ${{ secrets.GRAFANA_ACCESS_POLICY_TOKEN }}


### PR DESCRIPTION
Plugins need to be signed so they can be installed in Grafana. This was only possible after the plugin was initially published to the Marketplace.